### PR TITLE
truly middlewared

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,15 @@
+{
+    "preset": "google",
+
+    "validateJSDoc": {
+        "checkParamNames": true,
+        "checkRedundantParams": true,
+        "requireParamTypes": true
+    },
+
+    "excludeFiles": [
+        "**/.AppleDouble/**",
+        "node_modules/**",
+        "tmp/**"
+    ]
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,16 @@
+{
+    "node"     : true,
+    "bitwise"  : true,
+    "undef"    : true,
+    "eqeqeq"   : true,
+    "forin"    : true,
+    "immed"    : true,
+    "noarg"    : true,
+    "unused"   : true,
+    "maxlen"   : 120,
+
+    "expr"     : true,
+    "laxcomma" : true,
+
+    "predef"   : ["describe", "it", "beforeEach", "afterEach"]
+}

--- a/index.js
+++ b/index.js
@@ -6,47 +6,196 @@
 
 'use strict';
 
-var isArray = require('util').isArray;
-var spawn = require('child_process').spawn;
-var createWriteStream = require('fs').createWriteStream;
-var debug = require('debug')('gitlab-webhook');
-var express = require('express');
-var app = express.application;
+var isArray = require('util').isArray
+  , createWriteStream = require('fs').createWriteStream
+  , ASSERT = require('assert')
+
+  , debug = require('debug')('gitlab-webhook')
+
+  , runner = require('./lib/runner')
+  , filters = require('./lib/filters');
+
+// legacy
+// module.exports = classicExports;
+// clean
+module.exports = api;
 
 /**
- * Given a string `cmd`, replace all values in {{}} with the matching value.
- *
- * An object is returned with two keys:
- * 
- *  - `cmd` {String} The base command to execute
- *  - 'args' {Array} Any arguments to pass to the `cmd`
- *
- * @param {String} cmd
- * @param {Object} params
- * @return {Object}
- * @api private
+ * Provides helper to simplify routes declarations
+ * @param {Object} opts
+ *   - {Array|Function} [ips='127.0.0.1'] - remote ip addresses filter
+ *   - {Array|Function} [branches=false] - refs filter
+ *   - {String} [tokenKey="token"] - param field name with security token
+ *   - {String|String[]} [token=false] - valid token values
+ *   - {boolean} [strict=false] - returns 403 error if some of filters failed
  */
+function api (opts) {
+  opts = opts || {};
 
-var prepareCommand = function(cmd, params) {
-  params = params || {};
-  var re = /{{([^{{}}]+)}}/gm;
-  var match;
-  var keys = [];
-  while ((match = re.exec(cmd))) keys.push(match[1]);
-  if (keys.length) {
-    keys.forEach(function(key) {
-      var segs = key.split('.');
-      var sub = params;
-      while (segs.length) sub = sub[segs.shift()];
-      cmd = cmd.replace(new RegExp('{{' + key + '}}', 'mg'), sub);
+  // prepare common data
+  var ips      = ('ips' in opts)? ips : ['127.0.0.1']
+    , branches = opts.branches || false
+    , token    = opts.token || false
+    , tokenKey = opts.tokenKey || 'token'
+    , webhookKey = opts.webhookKey || 'webhook';
+
+  // prepare outgoing middlewares array
+  var middlewares = [];
+
+  // add needed filters
+  if (ips) {
+    debug('Adding ips filter: %s', ips);
+    middlewares.push(filters.ips({ips: ips}, opts.strict && fail));
+  }
+
+  if (token) {
+    debug('Adding tokens filter: %s', token);
+    middlewares.push(filters.token({tokenKey: tokenKey, token: token}, opts.strict && fail));
+  }
+
+  if (branches) {
+    debug('Adding branches filter: %s', branches);
+    middlewares.push(filters.branches({branches: branches}));
+  }
+
+  ASSERT(middlewares.length, "Invalid webhook configuration. Need some filters to apply handler");
+
+  middlewares.push(function (req, res, next) {
+    if (!req.body) {
+      next('route');
+    }
+
+    req[webhookKey] = unifyBodyData(req.body);
+
+    next();
+  });
+
+  if (opts.exec) {
+    // add common middleware to patch objects
+    middlewares.push(function (req, res, next) {
+      try {
+        var runnerOpts = runner.prepareCommand(opts.exec, req[webhookKey]);
+        if (opts.execLog) {
+          runnerOpts.outStream = createWriteStream(runner.prepareLogFile(opts.execLog, req[webhookKey]));
+        }
+        debug('$ ' + runnerOpts.cmd + ' ' + runnerOpts.args.join(' '));
+
+        runner.run(runnerOpts, function (err, result) {
+          /*jshint unused:false*/
+          if (err) {
+            debug('error: ' + err.message);
+            res.send(500);
+            return res.end();
+          }
+          next();
+        });
+
+      } catch (err) {
+        debug('error: ' + err.message);
+        res.send(500);
+        return res.end();
+      }
     });
   }
-  var comps = cmd.split(' ');
-  return {
-    cmd: comps.shift(),
-    args: comps
+
+  return middlewares;
+}
+
+// default fail express middleware function
+function fail (req, res, next) {
+  /*jshint unused:false*/
+  res.send(403);
+  return res.end();
+}
+
+/**
+ * reads and unifies push payloads and gitlab hook data
+ * @param {Object} body - incoming data
+ * @returns {Object} unified webhook data
+ *   - {String} kind - kind or event
+ *   - {}
+ */
+function unifyBodyData (b) {
+  var data = {}, obj;
+
+  switch (true) {
+  case b.object_kind === 'issue':
+  case b.object_kind === 'merge_request':
+    data.kind    = b.object_kind;
+    data.object  = obj = b.object_attributes;
+    data.state   = obj.state;
+    data.user_id = obj.author_id;
+
+    data.object_kind = b.object_kind;
+    data.object_attributes = b.object_attributes;
+    break;
+
+  case b.ref && b.repository && true:
+    var refa = b.ref.split(/\//)
+      , refName = refa.slice(2).join('/')
+      , tag    = refa[1] === 'tags'? refName : null
+      , branch = refa[1] === 'heads'? refName : null
+      , empty0 = Number(b.before) === 0
+      , empty1 = Number(b.after) === 0;
+
+    data.kind   = 'push';
+
+    // additional
+    data.action = (empty0 && 'create') || (!empty0 && !empty1 && 'update') || (empty1 && 'delete');
+    data.entity = (tag && 'tag') || (branch && 'branch') || ('unknown');
+    data.event  = [data.action, data.entity].join('-');
+
+    // primary data
+    data.branch  = branch;
+    data.tag     = tag;
+    data.treeish = empty1? null : b.after;
+    data.ref     = data.branch || data.tag || null;
+    data.user_id = b.user_id;
+    data.object  = data.payload = b;
+    break;
+
+  default:
+    data.kind   = 'unknown';
+    data.object = b;
+  }
+  return data;
+}
+
+// legacy version: patching globals
+(function (express) {
+  var app = express.application;
+
+  /**
+   * Expose HTTP
+   * @param {Object=} opts
+   *   - {Object} route
+   */
+  module.exports.http = function(opts) {
+    opts = opts || {};
+    return express().gitlab(opts.route || '/gitlab-hook', opts);
   };
-};
+
+  /**
+   * Execute a command when an authenticated webhook POSTs for an allowed branch.
+   *
+   * Options:
+   *   - param {String} name of parameter of token (default: token)
+   *   - token {String} content of token to match (default: none)
+   *   - branches {String|Array} list of branches to allow (default: *)
+   *   - ips {String|Array} list of ip addresses to allow (default: 127.0.0.1)
+   *   - exec {String} command to run if allowed (default: git pull <branch>)
+   *   - log {String} path of file to log output of execution to (default: ./logs/deploy.log)
+   *
+   * @param {String} route
+   * @param {Options} opts
+   * @return {Function}
+   * @api public
+   */
+  app.github =
+  app.gitlab = function(route, opts) {
+    return this.post(route, [express.bodyParser(), classicExports(opts)]);
+  };
+}(require('express')));
 
 /**
  * Execute a command when an authenticated webhook POSTs for an allowed branch.
@@ -64,60 +213,63 @@ var prepareCommand = function(cmd, params) {
  * @return {Function}
  * @api public
  */
-
-exports = module.exports = function(opts) {
+function classicExports (opts) {
   opts = opts || {};
-  
-  return function(req, res) {
-    var param = opts.param || 'token';
-    var token = req.param(param);
-    var payload = req.body || {};
-    var branches = opts.branches || ['*'];
-    var ips = opts.ips || ['127.0.0.1'];
-    var ref = payload.ref;
-    var ip = req.ip;
-    var cmd = opts.exec || 'git pull ' + ref;
-    var log = opts.log || './logs/deploy.log';
-    
-    branches = isArray(branches)? branches : [branches];
-    ips = isArray(ips)? ips : [ips];
-    
+
+  // prepare common data
+  var param    = opts.param || 'token'
+    , branches = opts.branches || ['*']
+    , ips      = opts.ips || ['127.0.0.1']
+    , log      = opts.log || './logs/deploy.log';
+
+  branches = isArray(branches)? branches : [branches];
+  ips = isArray(ips)? ips : [ips];
+
+  // return prepared express middleware function
+  return function (req, res) {
+    var token    = req.param(param)
+      , payload  = req.body || {}
+      , ref      = payload.ref
+      , ip       = req.ip
+      , cmd      = opts.exec || ('git pull ' + ref);
+
     debug('new hook request from %s for %s', ip, ref);
-    
+
+    // filter by ip
     if (ips.indexOf('*') === -1 && ips.indexOf(ip) === -1) {
       debug('%s not found in allowed ips: %s', ip, ips.join(', '));
-      res.status(404);
+      res.send(404);
       return res.end();
     }
-    
+
+    // filter by gitlab token value
     if (token !== opts.token) {
       debug('%s "%s" does not match', param, token);
-      res.status(404);
+      res.send(404);
       return res.end();
     }
-    
+
+    // filter by branches
     if (branches.indexOf('*') === -1 && branches.indexOf(ref) === -1) {
       debug('%s not found in allowed branches: %s', ref, branches.join(', '));
-      res.status(403);
+      res.send(403);
       return res.end();
     }
-    
+
+    // execute command
     debug('%s branch allowed', ref);
     try {
-      var run = prepareCommand(cmd, payload);
-      var out = createWriteStream(log, { flags: 'a', encoding: 'utf8' });
-      debug('$ ' + run.cmd + ' ' + run.args.join(' '));
-      out.once('error', function(err) {
-        debug('error: ' + err.message);
-        res.send(500);
-        return res.end();
-      });
-      out.once('open', function() {
-        var child = spawn(run.cmd, run.args, {
-          detached: true,
-          stdio: [ 'ignore', out, out ]
-        });
-        child.unref();
+      var runnerOpts = runner.prepareCommand(cmd, payload);
+      runnerOpts.outStream = createWriteStream(log);
+      debug('$ ' + runnerOpts.cmd + ' ' + runnerOpts.args.join(' '));
+
+      runner.run(runnerOpts, function (err, result) {
+        /*jshint unused:false*/
+        if (err) {
+          debug('error: ' + err.message);
+          res.send(500);
+          return res.end();
+        }
         res.send(200);
         return res.end();
       });
@@ -127,35 +279,4 @@ exports = module.exports = function(opts) {
       return res.end();
     }
   };
-};
-
-/**
- * Expose HTTP
- */
-
-module.exports.http = function(opts) {
-  opts = opts || {};
-  return express().gitlab(opts.route || '/gitlab-hook', opts);
 }
- 
-/**
- * Execute a command when an authenticated webhook POSTs for an allowed branch.
- *
- * Options:
- *   - param {String} name of parameter of token (default: token)
- *   - token {String} content of token to match (default: none)
- *   - branches {String|Array} list of branches to allow (default: *)
- *   - ips {String|Array} list of ip addresses to allow (default: 127.0.0.1)
- *   - exec {String} command to run if allowed (default: git pull <branch>)
- *   - log {String} path of file to log output of execution to (default: ./logs/deploy.log)
- *
- * @param {String} route
- * @param {Options} opts
- * @return {Function}
- * @api public
- */
-
-app.github =
-app.gitlab = function(route, opts) {
-  return this.post(route, [express.bodyParser(), exports(opts)]);
-};

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -1,0 +1,108 @@
+
+var isArray = require('util').isArray
+  , ASSERT = require('assert');
+
+// api
+module.exports = {
+  ips      : ipsFilterMiddlewareGenerator,
+  token    : tokenFilterMiddlewareGenerator,
+  branches : branchesFilterMiddlewareGenerator
+};
+
+/**
+ * Generate filter by ip middleware
+ * @param {Object} opts
+ *   - {String|String[]|Function} ips
+ * @param {Function=} fail
+ * @returns {Function} express middleware
+ * @todo add complex network and wildcard tests
+ */
+function ipsFilterMiddlewareGenerator (opts, fail) {
+  ASSERT(opts && opts.ips);
+  fail = skipRouteIfEmpty(fail);
+
+  var filter = makeSimpleFilter(opts.ips);
+
+  return function (req, res, next) {
+    filter(req.ip)? next() : fail(req, res, next);
+  };
+}
+
+/**
+ * Generate filter by token and req.body[tokenKey] middleware
+ * @param {Object} opts
+ *   - {String|String[]|Function} token
+ *   - {String} [tokenKey=token]
+ * @param {Function=} fail
+ * @returns {Function} express middleware
+ */
+function tokenFilterMiddlewareGenerator (opts, fail) {
+  ASSERT(opts && opts.token && opts.tokenKey);
+  fail = skipRouteIfEmpty(fail);
+
+  var filter = makeSimpleFilter(opts.token)
+    , tokenKey = opts.tokenKey;
+
+  return function (req, res, next) {
+    filter(req.param(tokenKey))? next() : fail(req, res, next);
+  };
+}
+
+/**
+ * Generate filter by branch (ref) middleware
+ * @param {Object} opts
+ *   - {String|String[]|Function} branches
+ * @param {Function=} fail
+ * @returns {Function} express middleware
+ */
+function branchesFilterMiddlewareGenerator (opts, fail) {
+  ASSERT(opts && opts.branches);
+  fail = skipRouteIfEmpty(fail);
+
+  var filter = makeSimpleFilter(opts.branches);
+
+  return function (req, res, next) {
+    filter(req.body.ref)? next() : fail(req, res, next);
+  };
+}
+
+/**
+ * skipRoute express middleware
+ * @param {http.ClientRequest} req
+ * @param {http.ServerResponse} res
+ * @param {Function} next
+ */
+function skipRouteMiddleware (req, res, next) {
+  next('route');
+}
+
+/**
+ * Simple list filter generator
+ * @param {Function|String|String[]} list - callback or list
+ * @returns {Function} filter
+ */
+function makeSimpleFilter (list) {
+  if (typeof list === 'function') {
+    return list;
+  }
+  if (isArray(list)) {
+    return function (item) {
+      return list.indexOf(item) !== -1;
+    };
+  }
+  return function (item) {
+    return list === item;
+  };
+}
+
+/**
+ * Tiny helper
+ * @param {Function=} fn
+ * @returns {Function}
+ */
+function skipRouteIfEmpty (fn) {
+  if (fn && fn.call) {
+    return fn;
+  }
+  return skipRouteMiddleware;
+}

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,0 +1,111 @@
+
+var ASSERT = require('assert')
+  , SPAWN = require('child_process').spawn;
+
+module.exports = {
+  prepareCommand : prepareCommand,
+  prepareLogFile : prepareLogFile,
+	run            : run
+};
+
+/**
+ * Given a string `cmd`, replace all values in {{}} with the matching value.
+ *
+ * An object is returned with two keys:
+ *
+ *  - `cmd` {String} The base command to execute
+ *  - 'args' {Array} Any arguments to pass to the `cmd`
+ *
+ * @param {String} cmd
+ * @param {Object=} params
+ * @returns {{cmd: String, args: String[]}}
+ * @api public
+ */
+function prepareCommand (cmd, params) {
+  params = params || {};
+
+  cmd = prepare(cmd, params);
+
+  return {
+    cmd: 'sh',
+    args: ['-c', cmd]
+  };
+}
+
+function prepareLogFile (str, params) {
+  return prepare(str, params);
+}
+
+var re = /{{([^{{}}]+)}}/gm
+  , keyReCache = {};
+
+function prepare (str, params) {
+  var match
+    , keys = []
+    , values = {};
+
+  if (str.call) {
+    str = str(params);
+  }
+
+  re.lastIndex = 0;
+  while ((match = re.exec(str))) {
+    keys.push(match[1]);
+  }
+
+  if (keys.length) {
+    Object.keys(params).forEach(function (k) {
+      values[k] = params[k];
+    });
+    Object.keys(params.payload).forEach(function (k) {
+      values[k] = params.payload[k];
+    });
+    keys.forEach(function(key) {
+      var segs = key.split('.');
+      var sub = values;
+      while (segs.length) {
+        sub = sub[segs.shift()];
+      }
+      keyReCache[key] = keyReCache[key] || new RegExp('{{' + key + '}}', 'mg');
+      str = str.replace(keyReCache[key], sub);
+    });
+  }
+
+  return str;
+}
+
+/**
+ * Run command
+ * @param {Object} opts
+ *   - {String} cmd
+ *   - {String[]} [args=]
+ *   - {stream.Writable} outStream
+ * @param {Function} cb
+ */
+function run (opts, cb) {
+  ASSERT(opts && opts.cmd);
+  ASSERT(cb);
+  opts = opts || {};
+  opts.args = opts.args || [];
+
+  if (!opts.outStream) {
+    _spawnDetached(opts.cmd, opts.args, 'ignore');
+    return;
+  }
+
+  opts.outStream
+    .once('error', cb)
+    .once('open', function () {
+      _spawnDetached(opts.cmd, opts.args, opts.outStream);
+    });
+
+  function _spawnDetached (cmd, args, out) {
+    var child = SPAWN(cmd, args, {
+      detached: true,
+      stdio: [ 'ignore', out, out ]
+    });
+    child.unref();
+    cb(null, {child: child});
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-webhook",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Express middleware to handle Github/Gitlab Webhook requests",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Moved execution helpers to runner
Created filters for ips/branches/tokens, added possibility to provide callback to each of them
Added possibility to provide callback to exec/execLog
Implemented webhookKey property to pass gitlab data to express request object

New syntax is more clean:

``` js
webhook = requre('gitlab-webhook');
app.post('/test',
    webhook({
        strict: true, // throw errors instead of bypassing route, as was before
        ips: false, // don't filter by ip
        token: function () { return true; },
        exec: 'echo "{{ref}}"; echo "{{user_id}}"; echo "{{payload.repository.homepage}}";',
        execLog: function (d) {
            return process.cwd() + '/logs/' + (d.ref.replace(/[^a-z0-9\-]+/ig,'-')) + '.exec_log';
        }
    }),
    function (req, res) {
        console.log(req.webhook);
        res.send(204);
        res.end();
    });
```

Tell me what you think about it.
